### PR TITLE
Add .markdown extension

### DIFF
--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -17,7 +17,7 @@ exports.provideBuilder = function () {
         return false;
       }
       var path = textEditor.getPath();
-      return path.endsWith('.md') || path.endsWith('.mkd');
+      return path.endsWith('.markdown') || path.endsWith('.md') || path.endsWith('.mkd');
     }
 
     settings() {


### PR DESCRIPTION
While `.md` is the universally most common file extension for Markdown, I'd like to add `.markdown` following this argument:

*"We no longer live in a 8.3 world, so we should be using the most descriptive file extensions. It’s sad that all our operating systems rely on this stupid convention instead of the better creator code or a metadata model, but great that they now support longer file extensions."*  
– Hilton Lipschitz ([via](http://hiltmon.com/blog/2012/03/07/the-markdown-file-extension/))

*"…the only file extension I would endorse is “.markdown”, for the same reason offered by Hilton Lipschitz"*  
– John Gruber, creator of Markdown ([via](http://daringfireball.net/linked/2014/01/08/markdown-extension))